### PR TITLE
Bug fixes; Support for diffs, blame stats; work with new gitstar Project

### DIFF
--- a/.env
+++ b/.env
@@ -2,6 +2,6 @@ SSH_PORT=5022
 SSH_KEY=/home/git/.ssh/id_rsa
 BASE_DIR=/tmp/repos
 AUTHORIZATION=Basic Z2l0c3Rhcjp3MDB0
-GITSTAR_URL=http://gitstar.lvh.me:5000/
+GITSTAR_URL=http://gitstar.lvh.me:8080/
 USERNAME=gitstar
 PASSWORD=w00t

--- a/gitstar-ssh-web/grapit.rb
+++ b/gitstar-ssh-web/grapit.rb
@@ -155,11 +155,9 @@ get "/repos/:user/:repo/git/commits/:sha/diff" do
   diff = with_repo params[:user], params[:repo] do |repo|
     repo.commit(params[:sha]).diffs.map do |diff|
       {
-        a_path:           diff.a_path,
-        b_path:           diff.b_path,
+        path:             diff.b_path,
         new_file:         diff.new_file,
         deleted_file:     diff.deleted_file,
-        renamed_file:     diff.renamed_file,
         similarity_index: diff.similarity_index,
         diff:             diff.diff
       }

--- a/gitstar-ssh-web/grapit.rb
+++ b/gitstar-ssh-web/grapit.rb
@@ -159,7 +159,7 @@ get "/repos/:user/:repo/git/commits/:sha/diff" do
         new_file:         diff.new_file,
         deleted_file:     diff.deleted_file,
         similarity_index: diff.similarity_index,
-        diff:             diff.diff
+        diff:             Base64.encode64(diff.diff)
       }
     end
   end
@@ -196,10 +196,10 @@ get "/repos/:user/:repo/git/blame/:sha/*" do
   commit = with_repo params[:user], params[:repo] do |repo|
     repo.blame(file,params[:sha]).lines.map do |line|
     {
-      lineno:    line.lineno,
-      oldlineno: line.oldlineno,
-      line:      Base64.encode64(line.line),
-      commit:    line.commit
+      lineno:     line.lineno,
+      old_lineno: line.oldlineno,
+      line:       Base64.encode64(line.line),
+      commit:     line.commit
     }
     end
   end

--- a/gitstar-ssh-web/grapit.rb
+++ b/gitstar-ssh-web/grapit.rb
@@ -63,6 +63,9 @@ end
 
 ## Tags
 
+#TODO: Once grit supports annotated tags properly, this function
+# should be modified as follows:
+# sha should correspond to the tag hash (not the object it points to)
 get "/repos/:user/:repo/tags" do
   with_repo params[:user], params[:repo] do |repo|
     tags = repo.tags.map do |tag|
@@ -79,18 +82,26 @@ end
 
 ## Getting a tag
 
+#TODO: Once grit supports annotated tags properly, this function
+# should be modified as follows:
+# sha should correspond to the tag hash (not the object it points to)
+# object.type should also have the right type: annotated tag can point
+# to a blob or tree in addition vs. just commit)
 get "/repos/:user/:repo/git/tags/:sha" do
   tags = with_repo params[:user], params[:repo] do |repo|
     tag = repo.tags.find(params[:sha]).first
     { tag: tag.name,
-      sha: tag.commit.id,
+#      sha: params[:sha],
       message: tag.message,
       tagger: {
           name: tag.tagger.name,
           email: tag.tagger.email,
           date: tag.tag_date
       },
-#TODO: object { type, sha }
+      object: {
+#        type: "commit",
+        sha: tag.commit.id
+      }
     }
   end
   toSON tags

--- a/gitstar-ssh-web/grapit.rb
+++ b/gitstar-ssh-web/grapit.rb
@@ -89,7 +89,7 @@ get "/repos/:user/:repo/git/tags/:sha" do
           name: tag.tagger.name,
           email: tag.tagger.email,
           date: tag.tag_date
-      }
+      },
 #TODO: object { type, sha }
     }
   end
@@ -146,7 +146,7 @@ get "/repos/:user/:repo/git/refs" do
         ref: "refs/#{type}s/#{ref.name}",
         object: {
           sha: ref.commit,
-          type: type
+          type: (type == "tag") ? "tag" : "commit"
         }
       }
     end
@@ -166,7 +166,7 @@ def get_reference(repo, ref_name)
     ref: "refs/#{type}s/#{ref.name}",
     object: {
       sha: ref.commit,
-      type: type
+      type: (type == "tag") ? "tag" : "commit"
     }
   }]
 end
@@ -181,7 +181,7 @@ def get_sub_namespace_references(repo, ref_name)
       ref: "refs/#{type}s/#{ref.name}",
       object: {
         sha: ref.commit,
-        type: type
+        type: (type == "tag") ? "tag" : "commit"
       }
     }
   end
@@ -225,7 +225,7 @@ get "/repos/:user/:repo/git/trees/:sha" do
   tree = with_repo params[:user], params[:repo] do |repo|
     tree = repo.tree(params[:sha])
     sub_trees = tree.trees.map {|t| makeTree(t)}
-    blobs = tree.blobs.map {|t| makeTree(t)}
+    blobs = tree.blobs.map {|t| makeBlob(t)}
     {
       sha: tree.id,
       tree: sub_trees + blobs

--- a/gitstar-ssh-web/grapit.rb
+++ b/gitstar-ssh-web/grapit.rb
@@ -1,6 +1,7 @@
 require 'sinatra'
 require 'json'
 require 'bson'
+require 'base64'
 require 'grit'
 
 BASE_DIR = ENV["BASE_DIR"]
@@ -113,7 +114,7 @@ get "/repos/:user/:repo/git/blobs/:sha" do
   blobs = with_repo params[:user], params[:repo] do |repo|
     blob = repo.blob(params[:sha])
     { 
-      content: blob.data,
+      content: Base64.encode64(blob.data),
       mime_type: blob.mime_type
     }
   end


### PR DESCRIPTION
- Fixed bugs (as a result of grapit not really handling annotated tags as separate objects)
  - Fixes bugs in tree
  - Makes the best of it in /tags : grit is broken at the core w.r.t. annotated tags. I will write an implementation with iterIO after submission
- Added support for diffs, blame, and stats
- Update readAccess check to use new toDocument implementation in Projects
